### PR TITLE
Update h-config.sh

### DIFF
--- a/hive/miners/xmr-stak/h-config.sh
+++ b/hive/miners/xmr-stak/h-config.sh
@@ -93,7 +93,7 @@ function miner_config_gen() {
 			currency='"currency" : "karbo"'
 		;;
 		XMR )
-			currency='"currency" : "monero7"'
+			currency='"currency" : "monero"'
 		;;
 		XTL )
 			currency='"currency" : "stellite"'


### PR DESCRIPTION
Since the v8 fork in Fall of 2018 XMR-STAK uses currency type 'monero'.
I updated my local h-config.sh file to correct this and the miner now functions.
- Based on a clean install on April 20, 2019:
Used: hive-flasher-20180910d.img and initial image: hiveos-vega-0.6-01@181121
Ran self upgrade to hiveos-vega-0.6-31@190418
Initial miner installed XMR-STAK—FIREICE-UK v2.10.4
Modified /hive/miners/xmr-stak/h-config.sh as indicated above