### PR TITLE
Update hive

### DIFF
--- a/hive/bin/hive
+++ b/hive/bin/hive
@@ -400,4 +400,8 @@ echo2 "> System start complete"
 # start console
 systemctl restart hive-console
 
+
+# restart network interface
+ifconfig eth0 down
+ifconfig eth0 up
 exit 0


### PR DESCRIPTION
Issue description: some Asus motherboards don't connect to the internet when rigs boot up.
Cause: Something with the 2.5gig port and it’s wake-on-lan setting, no proper kernel support yet.

Example Motherboard: PRIME Z490-A ASUS
I225-V 2.5Gb Ethernet

There are many references on Discord, here are some online:
https://www.reddit.com/r/HiveOS/comments/m48mnp/network_down_on_hive_boot/
https://forum.hiveos.farm/t/issue-with-z490-asus-prime-board/26619
https://help.ubuntu.com/community/WakeOnLan#:~:text=To%20enable%20WoL%20in%20the,Save%20your%20settings%20and%20reboot
https://www.reddit.com/r/EtherMining/comments/ljxrg4/has_anyone_figured_out_how_to_start_the_ethernet/


Solution 1: Ethernet to USB adapter, $15-$20 per rig, gets pricy with more rigs.

Solution 2: 
nano /hive/bin/hive
ifconfig eth0 down
ifconfig eth0 up

Solution 2 fails when HiveOS updates as it resets the file "/hive/bin/hive"

Possible Solution 3: include the following by default "/hive/bin/hive", There won't be a cost to any other user.
ifconfig eth0 down
ifconfig eth0 up